### PR TITLE
Add support for adding task roles to the task

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ module "ecs_scheduled_task" {
   create_ecs_task_execution_role = false
   ecs_task_execution_role_arn    = var.ecs_events_role_arn
 
+  create_ecs_task_role = false
+  ecs_task_role_arn    = var.ecs_task_role_arn
+
   tags = {
     Environment = "prod"
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -127,3 +127,13 @@ output "ecs_task_execution_policy_document" {
   value       = join("", aws_iam_policy.ecs_task_execution.*.policy)
   description = "The policy document of the ECS Task Execution IAM Policy."
 }
+
+output "ecs_task_role_arn" {
+  value       = join("", aws_iam_role.ecs_task_role.*.arn)
+  description = "The ARN assigned by AWS to this ECS Task IAM Policy."
+}
+
+output "ecs_task_role_name" {
+  value       = join("", aws_iam_role.ecs_task_role.*.name)
+  description = "The name of the ECS Task IAM Role."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -118,3 +118,15 @@ variable "ecs_task_execution_role_arn" {
   type        = string
   description = "The ARN of the ECS Task Execution IAM Role."
 }
+
+variable "create_ecs_task_role" {
+  default     = true
+  type        = string
+  description = "Specify true to indicate that ECS Task IAM Role creation."
+}
+
+variable "ecs_task_role_arn" {
+  default     = ""
+  type        = string
+  description = "The ARN of the ECS Task IAM Role."
+}


### PR DESCRIPTION
This addition will allow your task to interact with the metadata api
as well as other AWS services.  This role is what the container will
assume when it is running.

https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html